### PR TITLE
Feature/themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ CHAT_DATA/
 node_modules/
 fable_modules/
 
+# IDE and build artifacts
+.claude
+.vscode/settings.json
+
 src/**/*.fs.js
 src/Client/public/
 test/e2e/Chrome

--- a/.idea/.idea.fschat/.idea/vcs.xml
+++ b/.idea/.idea.fschat/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#120F96",
-        "titleBar.activeBackground": "#1A15D2",
-        "titleBar.activeForeground": "#FDFDFF"
-    }
-}

--- a/src/Client/App/State.fs
+++ b/src/Client/App/State.fs
@@ -4,6 +4,26 @@ open Elmish
 open Elmish.Navigation
 open Router
 open Types
+open Browser.Dom
+open Browser.WebStorage
+
+let private setThemeClass theme =
+    let className = "theme-" + theme
+    document.documentElement.className <- className
+
+let private loadThemeFromStorage () =
+    try
+        localStorage.getItem("selected-theme")
+        |> Option.ofObj
+        |> Option.defaultValue "mass-effect"
+    with
+    | _ -> "mass-effect"
+
+let private saveThemeToStorage theme =
+    try
+        localStorage.setItem("selected-theme", theme)
+    with
+    | _ -> ()
 
 let urlUpdate (result: Option<Route>) model =
     match result with
@@ -15,7 +35,9 @@ let urlUpdate (result: Option<Route>) model =
 
 let init result =
     let connModel, connCmd = Connection.State.init()
-    let model, cmd = urlUpdate result { currentPage = Overview; chatPage = connModel }
+    let savedTheme = loadThemeFromStorage()
+    setThemeClass savedTheme
+    let model, cmd = urlUpdate result { currentPage = Overview; chatPage = connModel; selectedTheme = savedTheme }
     model, Cmd.batch [
         cmd
         Cmd.map ChatDataMsg connCmd
@@ -26,3 +48,7 @@ let update msg model =
     | ChatDataMsg msg ->
         let (chinfo, chinfoCmd) = Connection.State.update msg model.chatPage
         { model with chatPage = chinfo }, Cmd.map ChatDataMsg chinfoCmd
+    | SetTheme theme ->
+        setThemeClass theme
+        saveThemeToStorage theme
+        { model with selectedTheme = theme }, Cmd.none

--- a/src/Client/App/Types.fs
+++ b/src/Client/App/Types.fs
@@ -2,8 +2,10 @@ module App.Types
 
 type Msg =
   | ChatDataMsg of Connection.Types.Msg
+  | SetTheme of string
 
 type Model = {
     currentPage: Router.Route
     chatPage: Connection.Types.Model
+    selectedTheme: string
   }

--- a/src/Client/App/View.fs
+++ b/src/Client/App/View.fs
@@ -33,7 +33,7 @@ let root model dispatch =
       [ ClassName "container" ]
       [ div
           [ ClassName "col-md-4 fs-menu" ]
-          (NavMenu.View.menu model.chatPage model.currentPage (ApplicationMsg >> ChatDataMsg >> dispatch))
+          (NavMenu.View.menu model.chatPage model.currentPage model.selectedTheme (SetTheme >> dispatch) (ApplicationMsg >> ChatDataMsg >> dispatch))
         div
           [ ClassName "col-xs-12 col-md-8 fs-chat" ]
           (mainAreaView model.currentPage) ]

--- a/src/Client/NavMenu/View.fs
+++ b/src/Client/NavMenu/View.fs
@@ -27,7 +27,31 @@ let menuItemChannelJoin dispatch =
     fun (ch: ChannelInfo) ->
       menuItem (OnClick <| join ch.Id) ch.Name ch.Topic false
 
-let menu (chatData: Model) currentPage dispatch =
+let themeSelector currentTheme themeDispatch =
+    let themeOptions = [
+        ("mass-effect", "Mass Effect")
+        ("cyberpunk", "Cyberpunk")
+        ("forest", "Forest")
+        ("ocean", "Ocean")
+        ("sunset", "Sunset")
+        ("monochrome", "Monochrome")
+    ]
+    
+    div [ ClassName "fs-theme-selector" ]
+        [ h4 [] [ str "Theme" ]
+          select 
+            [ Value currentTheme
+              OnChange (fun ev ->
+                let themeValue = !!ev.target?value
+                themeDispatch themeValue) ]
+            [ for (themeValue, name) in themeOptions ->
+                option 
+                  [ Value themeValue ]
+                  [ str name ]
+            ]
+        ]
+
+let menu (chatData: Connection.Types.Model) currentPage currentTheme themeDispatch dispatch =
     match chatData with
     | NotConnected ->
       [ div [] [str "not connected"] ]
@@ -74,4 +98,5 @@ let menu (chatData: Model) currentPage dispatch =
         for (chid, ch) in channelList |> Map.toSeq do
             if not(channels |> Map.containsKey chid) then
                 yield menuItemChannelJoin dispatch ch
+        yield themeSelector currentTheme themeDispatch
       ]

--- a/src/Client/UserAvatar/View.fs
+++ b/src/Client/UserAvatar/View.fs
@@ -6,7 +6,8 @@ open Fable.React.Props
 let root  =
   function
   | None | Some "" ->
-      div [ ClassName "fs-avatar" ] []
+      div [ ClassName "fs-avatar" ] 
+          [ i [ ClassName "mdi mdi-account" ] [] ]
 
   | Some url ->
       div

--- a/src/Client/sass/app.scss
+++ b/src/Client/sass/app.scss
@@ -1,4 +1,5 @@
 @use 'sass:color';
+@use './themes/index';
 @use './variables' as *;
 @use './chat';
 @use './menu';

--- a/src/Client/sass/app.scss
+++ b/src/Client/sass/app.scss
@@ -82,7 +82,6 @@ html, body {
 		text-align: center;
 
 		color: white;
-		background-color: $color-avatar-bg;
 
 		font-size: 24px;
 		line-height: 40px;

--- a/src/Client/sass/chat.scss
+++ b/src/Client/sass/chat.scss
@@ -178,7 +178,9 @@
 		content: ' ';
 
 		border-radius: 25px 25px 0 0;
-		background-color: #f7f5fb;
+		background-color: $color-chat-bg;
+
+
 	}
 
 	> div:not(.fs-avatar) {
@@ -191,6 +193,7 @@
 			margin: 0;
 			padding: 0;
 
+			color: $color-msg-text;
 			line-height: 20px;
 		}
 
@@ -199,6 +202,7 @@
 			margin: 0;
 			padding: 0;
 
+			color: $color-msg-text;
 			font-size: $font-size-sm;
 			line-height: 20px;
 
@@ -225,7 +229,7 @@
 	}
 
 	&.user {
-		color: white;
+		color: $color-user-msg-text;
 
 		&::before {
 			right: 15px;
@@ -237,6 +241,14 @@
 			padding: 10px 30px 5px 10px;
 
 			background-color: $color-user-msg-bg;
+
+			p {
+				color: $color-user-msg-text;
+			}
+
+			h5 {
+				color: $color-user-msg-text;
+			}
 		}
 
 		.fs-avatar {

--- a/src/Client/sass/menu.scss
+++ b/src/Client/sass/menu.scss
@@ -2,8 +2,9 @@
 @use './variables' as *;
 
 .fs-menu {
+	position: relative;
 	height: 100%;
-	padding: 0;
+	padding: 0 0 80px 0;
 
 	background-color: $color-menu-bg;
 }
@@ -219,7 +220,7 @@
 
 	color: white;
 	border: none;
-	background-color: color.adjust($color-menu-bg, $lightness: 5%);
+	background-color: var(--background-secondary, rgba(65, 66, 111, 0.9));
 
 	line-height: 0;
 
@@ -236,7 +237,7 @@
 
 		&:focus {
 			outline: none;
-			background-color: color.adjust($color-menu-bg, $lightness: 15%);
+			background-color: var(--background-primary, rgba(65, 66, 111, 1));
 		}
 	}
 }
@@ -250,12 +251,53 @@
 	height: 50px;
 	
 	color: white;
-	background-color: color.adjust($color-menu-bg, $lightness: 10%);
+	background-color: var(--background-secondary, rgba(75, 76, 131, 1));
 	border: none;
 	
 	font-size: 18px;
 	
 	&:hover {
-		background-color: color.adjust($color-menu-bg, $lightness: 20%);
+		background-color: var(--background-primary, rgba(85, 86, 151, 1));
+	}
+}
+
+.fs-theme-selector {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	padding: 15px;
+	border-top: 1px solid rgba(#000, .2);
+	background-color: $color-menu-bg;
+	
+	h4 {
+		margin: 0 0 10px 0;
+		color: $color-menu-fg;
+		font-size: $font-size-sm;
+		font-weight: normal;
+		text-transform: uppercase;
+		opacity: .8;
+	}
+	
+	select {
+		width: 100%;
+		padding: 8px 12px;
+		background-color: var(--background-secondary, rgba(75, 76, 131, 1));
+		border: 1px solid var(--color-accent, rgba(105, 106, 171, 1));
+		border-radius: $border-radius;
+		color: $color-menu-fg;
+		font-size: $font-size-sm;
+		cursor: pointer;
+		
+		&:focus {
+			outline: none;
+			border-color: var(--color-accent, rgba(135, 136, 201, 1));
+			background-color: var(--background-primary, rgba(95, 96, 151, 1));
+		}
+		
+		option {
+			background-color: $color-menu-bg;
+			color: $color-menu-fg;
+		}
 	}
 }

--- a/src/Client/sass/menu.scss
+++ b/src/Client/sass/menu.scss
@@ -168,7 +168,7 @@
 	}
 
 	&.selected {
-		color: $color-menu-bg;
+		color: $color-menu-selected;
 		background-color: $color-chat-bg;
 
 		&::after {

--- a/src/Client/sass/themes/_cyberpunk.scss
+++ b/src/Client/sass/themes/_cyberpunk.scss
@@ -1,0 +1,42 @@
+// Cyberpunk Theme - Neon and dark aesthetic
+:root.theme-cyberpunk {
+  // Avatar colors
+  --color-avatar-bg: #FF0080;
+  
+  // Menu colors
+  --color-menu-fg: #00FF41;
+  --color-menu-bg: #0A0A0A;
+  
+  // Text colors
+  --color-text: #E5E5E5;
+  
+  // Chat colors
+  --color-chat-bg: #1A1A1A;
+  
+  // Message colors
+  --color-msg-bg: #2D2D2D;
+  --color-user-msg-bg: #FF0080;
+  
+  // UI elements
+  --border-radius: 0px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Cyberpunk specific colors
+  --color-accent: #00FF41;
+  --color-warning: #FFFF00;
+  --color-success: #00FF41;
+  --color-danger: #FF0080;
+  
+  // Neon backgrounds
+  --background-primary: linear-gradient(135deg, #0A0A0A 0%, #1A0033 100%);
+  --background-secondary: rgba(10, 10, 10, 0.95);
+  
+  // Neon glowing effects
+  --glow-primary: 0 0 20px rgba(0, 255, 65, 0.5);
+  --glow-secondary: 0 0 15px rgba(255, 0, 128, 0.4);
+  --glow-text: 0 0 5px currentColor;
+}

--- a/src/Client/sass/themes/_cyberpunk.scss
+++ b/src/Client/sass/themes/_cyberpunk.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #00FF41;
   --color-menu-bg: #0A0A0A;
+  --color-menu-selected: #00FF41;
   
   // Text colors
   --color-text: #E5E5E5;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #2D2D2D;
+  --color-msg-text: #E5E5E5;
   --color-user-msg-bg: #FF0080;
+  --color-user-msg-text: #000000;
   
   // UI elements
   --border-radius: 0px;

--- a/src/Client/sass/themes/_forest.scss
+++ b/src/Client/sass/themes/_forest.scss
@@ -1,0 +1,41 @@
+// Forest Theme - Natural greens and earth tones
+:root.theme-forest {
+  // Avatar colors
+  --color-avatar-bg: #059669;
+  
+  // Menu colors
+  --color-menu-fg: #F0FDF4;
+  --color-menu-bg: #14532D;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #ECFDF5;
+  
+  // Message colors
+  --color-msg-bg: #D1FAE5;
+  --color-user-msg-bg: #047857;
+  
+  // UI elements
+  --border-radius: 8px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Forest specific colors
+  --color-accent: #10B981;
+  --color-warning: #F59E0B;
+  --color-success: #059669;
+  --color-earth: #92400E;
+  
+  // Natural backgrounds
+  --background-primary: linear-gradient(135deg, #14532D 0%, #166534 100%);
+  --background-secondary: rgba(20, 83, 45, 0.9);
+  
+  // Subtle natural effects
+  --glow-primary: 0 0 8px rgba(16, 185, 129, 0.2);
+  --glow-secondary: 0 0 4px rgba(5, 150, 105, 0.1);
+}

--- a/src/Client/sass/themes/_forest.scss
+++ b/src/Client/sass/themes/_forest.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #F0FDF4;
   --color-menu-bg: #14532D;
+  --color-menu-selected: #1F2937;
   
   // Text colors
   --color-text: #1F2937;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #D1FAE5;
+  --color-msg-text: #1F2937;
   --color-user-msg-bg: #047857;
+  --color-user-msg-text: #FFFFFF;
   
   // UI elements
   --border-radius: 8px;

--- a/src/Client/sass/themes/_index.scss
+++ b/src/Client/sass/themes/_index.scss
@@ -1,0 +1,48 @@
+// Import all theme files
+@use 'mass-effect';
+@use 'cyberpunk';
+@use 'forest';
+@use 'ocean';
+@use 'sunset';
+@use 'monochrome';
+
+// Default theme (Mass Effect)
+:root {
+  // Avatar colors
+  --color-avatar-bg: #1E3A8A;
+  
+  // Menu colors
+  --color-menu-fg: #E0E7FF;
+  --color-menu-bg: #1E1B4B;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #EDE9FE;
+  
+  // Message colors
+  --color-msg-bg: #C7D2FE;
+  --color-user-msg-bg: #3730A3;
+  
+  // UI elements
+  --border-radius: 4px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Additional Mass Effect themed colors
+  --color-accent: #00D4FF;
+  --color-warning: #FF6B35;
+  --color-success: #10B981;
+  
+  // Enhanced backgrounds
+  --background-primary: linear-gradient(135deg, #1E1B4B 0%, #312E81 100%);
+  --background-secondary: rgba(30, 27, 75, 0.9);
+  
+  // Glowing effects
+  --glow-primary: 0 0 10px rgba(0, 212, 255, 0.3);
+  --glow-secondary: 0 0 5px rgba(0, 212, 255, 0.2);
+}

--- a/src/Client/sass/themes/_index.scss
+++ b/src/Client/sass/themes/_index.scss
@@ -24,6 +24,7 @@
   // Message colors
   --color-msg-bg: #C7D2FE;
   --color-user-msg-bg: #3730A3;
+  --color-user-msg-text: #FFFFFF;
   
   // UI elements
   --border-radius: 4px;

--- a/src/Client/sass/themes/_mass-effect.scss
+++ b/src/Client/sass/themes/_mass-effect.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #E0E7FF;
   --color-menu-bg: #1E1B4B;
+  --color-menu-selected: #1F2937;
   
   // Text colors
   --color-text: #1F2937;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #C7D2FE;
+  --color-msg-text: #1F2937;
   --color-user-msg-bg: #3730A3;
+  --color-user-msg-text: #FFFFFF;
   
   // UI elements
   --border-radius: 4px;

--- a/src/Client/sass/themes/_mass-effect.scss
+++ b/src/Client/sass/themes/_mass-effect.scss
@@ -1,0 +1,40 @@
+// Mass Effect Theme - Enhanced futuristic styling
+:root.theme-mass-effect {
+  // Avatar colors
+  --color-avatar-bg: #1E3A8A;
+  
+  // Menu colors
+  --color-menu-fg: #E0E7FF;
+  --color-menu-bg: #1E1B4B;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #EDE9FE;
+  
+  // Message colors
+  --color-msg-bg: #C7D2FE;
+  --color-user-msg-bg: #3730A3;
+  
+  // UI elements
+  --border-radius: 4px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Additional Mass Effect themed colors
+  --color-accent: #00D4FF;
+  --color-warning: #FF6B35;
+  --color-success: #10B981;
+  
+  // Enhanced backgrounds
+  --background-primary: linear-gradient(135deg, #1E1B4B 0%, #312E81 100%);
+  --background-secondary: rgba(30, 27, 75, 0.9);
+  
+  // Glowing effects
+  --glow-primary: 0 0 10px rgba(0, 212, 255, 0.3);
+  --glow-secondary: 0 0 5px rgba(0, 212, 255, 0.2);
+}

--- a/src/Client/sass/themes/_monochrome.scss
+++ b/src/Client/sass/themes/_monochrome.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #F9FAFB;
   --color-menu-bg: #111827;
+  --color-menu-selected: #1F2937;
   
   // Text colors
   --color-text: #1F2937;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #E5E7EB;
+  --color-msg-text: #1F2937;
   --color-user-msg-bg: #374151;
+  --color-user-msg-text: #FFFFFF;
   
   // UI elements
   --border-radius: 2px;

--- a/src/Client/sass/themes/_monochrome.scss
+++ b/src/Client/sass/themes/_monochrome.scss
@@ -1,0 +1,41 @@
+// Monochrome Theme - Black, white, and grays
+:root.theme-monochrome {
+  // Avatar colors
+  --color-avatar-bg: #374151;
+  
+  // Menu colors
+  --color-menu-fg: #F9FAFB;
+  --color-menu-bg: #111827;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #F9FAFB;
+  
+  // Message colors
+  --color-msg-bg: #E5E7EB;
+  --color-user-msg-bg: #374151;
+  
+  // UI elements
+  --border-radius: 2px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Monochrome specific colors
+  --color-accent: #6B7280;
+  --color-warning: #9CA3AF;
+  --color-success: #4B5563;
+  --color-dark: #030712;
+  
+  // Minimal backgrounds
+  --background-primary: linear-gradient(135deg, #111827 0%, #1F2937 100%);
+  --background-secondary: rgba(17, 24, 39, 0.95);
+  
+  // Subtle effects
+  --glow-primary: 0 0 5px rgba(107, 114, 128, 0.2);
+  --glow-secondary: 0 0 3px rgba(75, 85, 99, 0.1);
+}

--- a/src/Client/sass/themes/_ocean.scss
+++ b/src/Client/sass/themes/_ocean.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #F0F9FF;
   --color-menu-bg: #0C4A6E;
+  --color-menu-selected: #1F2937;
   
   // Text colors
   --color-text: #1F2937;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #E0F2FE;
+  --color-msg-text: #1F2937;
   --color-user-msg-bg: #0369A1;
+  --color-user-msg-text: #FFFFFF;
   
   // UI elements
   --border-radius: 6px;

--- a/src/Client/sass/themes/_ocean.scss
+++ b/src/Client/sass/themes/_ocean.scss
@@ -1,0 +1,41 @@
+// Ocean Theme - Blues and teals
+:root.theme-ocean {
+  // Avatar colors
+  --color-avatar-bg: #0891B2;
+  
+  // Menu colors
+  --color-menu-fg: #F0F9FF;
+  --color-menu-bg: #0C4A6E;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #F0F9FF;
+  
+  // Message colors
+  --color-msg-bg: #E0F2FE;
+  --color-user-msg-bg: #0369A1;
+  
+  // UI elements
+  --border-radius: 6px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Ocean specific colors
+  --color-accent: #06B6D4;
+  --color-warning: #F59E0B;
+  --color-success: #10B981;
+  --color-deep: #164E63;
+  
+  // Oceanic backgrounds
+  --background-primary: linear-gradient(135deg, #0C4A6E 0%, #075985 100%);
+  --background-secondary: rgba(12, 74, 110, 0.9);
+  
+  // Water-like effects
+  --glow-primary: 0 0 12px rgba(6, 182, 212, 0.3);
+  --glow-secondary: 0 0 6px rgba(8, 145, 178, 0.2);
+}

--- a/src/Client/sass/themes/_sunset.scss
+++ b/src/Client/sass/themes/_sunset.scss
@@ -6,6 +6,7 @@
   // Menu colors
   --color-menu-fg: #FEF3C7;
   --color-menu-bg: #92400E;
+  --color-menu-selected: #1F2937;
   
   // Text colors
   --color-text: #1F2937;
@@ -15,7 +16,9 @@
   
   // Message colors
   --color-msg-bg: #FED7AA;
+  --color-msg-text: #1F2937;
   --color-user-msg-bg: #EA580C;
+  --color-user-msg-text: #000000;
   
   // UI elements
   --border-radius: 12px;

--- a/src/Client/sass/themes/_sunset.scss
+++ b/src/Client/sass/themes/_sunset.scss
@@ -1,0 +1,41 @@
+// Sunset Theme - Warm oranges, reds, and golden colors
+:root.theme-sunset {
+  // Avatar colors
+  --color-avatar-bg: #DC2626;
+  
+  // Menu colors
+  --color-menu-fg: #FEF3C7;
+  --color-menu-bg: #92400E;
+  
+  // Text colors
+  --color-text: #1F2937;
+  
+  // Chat colors
+  --color-chat-bg: #FEF3C7;
+  
+  // Message colors
+  --color-msg-bg: #FED7AA;
+  --color-user-msg-bg: #EA580C;
+  
+  // UI elements
+  --border-radius: 12px;
+  
+  // Typography
+  --font-size-sm: 12px;
+  --font-size: 14px;
+  --font-size-lg: 16px;
+
+  // Sunset specific colors
+  --color-accent: #F59E0B;
+  --color-warning: #EF4444;
+  --color-success: #10B981;
+  --color-gold: #D97706;
+  
+  // Warm sunset backgrounds
+  --background-primary: linear-gradient(135deg, #92400E 0%, #C2410C 100%);
+  --background-secondary: rgba(146, 64, 14, 0.9);
+  
+  // Warm glowing effects
+  --glow-primary: 0 0 15px rgba(245, 158, 11, 0.4);
+  --glow-secondary: 0 0 8px rgba(234, 88, 12, 0.3);
+}

--- a/src/Client/sass/variables.scss
+++ b/src/Client/sass/variables.scss
@@ -1,16 +1,19 @@
-$color-avatar-bg: #67688C;
+// Using CSS custom properties for theming
+// These variables will be overridden by theme-specific values
 
-$color-menu-fg: #fff;
-$color-menu-bg: #41426F;
-$color-text: #343434;
+$color-avatar-bg: var(--color-avatar-bg);
 
-$color-chat-bg: #F7F5FB;
+$color-menu-fg: var(--color-menu-fg);
+$color-menu-bg: var(--color-menu-bg);
+$color-text: var(--color-text);
 
-$color-msg-bg: #E1DFE5;
-$color-user-msg-bg: #41426F;
+$color-chat-bg: var(--color-chat-bg);
 
-$border-radius: 2px;
+$color-msg-bg: var(--color-msg-bg);
+$color-user-msg-bg: var(--color-user-msg-bg);
 
-$font-size-sm: 12px;
-$font-size: 14px;
-$font-size-lg: 16px;
+$border-radius: var(--border-radius);
+
+$font-size-sm: var(--font-size-sm);
+$font-size: var(--font-size);
+$font-size-lg: var(--font-size-lg);

--- a/src/Client/sass/variables.scss
+++ b/src/Client/sass/variables.scss
@@ -5,12 +5,15 @@ $color-avatar-bg: var(--color-avatar-bg);
 
 $color-menu-fg: var(--color-menu-fg);
 $color-menu-bg: var(--color-menu-bg);
+$color-menu-selected: var(--color-menu-selected, var(--color-menu-fg));
 $color-text: var(--color-text);
 
 $color-chat-bg: var(--color-chat-bg);
 
 $color-msg-bg: var(--color-msg-bg);
+$color-msg-text: var(--color-msg-text, var(--color-text));
 $color-user-msg-bg: var(--color-user-msg-bg);
+$color-user-msg-text: var(--color-user-msg-text, inherit);
 
 $border-radius: var(--border-radius);
 


### PR DESCRIPTION

This pull request introduces a theme system for the chat application, allowing users to select and persist different visual themes. It includes the implementation of six distinct themes, a theme selector UI, logic for saving and restoring the selected theme, and updates to use CSS variables for styling. 

**UI improvements:**

- Added a default user avatar icon for users without an avatar image.
- Improved the theme selector UI in the navigation menu, including styling for the dropdown to match the selected theme.

**Cleanup:**

- Removed obsolete IDE and VSCode configuration files. (.idea/.idea.fschat/.idea/vcs.xml, .vscode/settings.json) [[1]](diffhunk://#diff-81445559db4ddd8ab5fa940bd445c877cabab08596bfdd1bfa6f35f110f66df9L1-L6) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L1-L7)